### PR TITLE
add BaseResponse with a status

### DIFF
--- a/psp/authorize.go
+++ b/psp/authorize.go
@@ -10,6 +10,7 @@ type AuthorizeRequest struct {
 }
 
 type AuthorizeResponse struct {
+	BaseResponse
 	TransactionResponse
 	ThreeDSResult    *ThreeDSResult `json:"3dsResult"`
 	AmountAuthorized Amount         `json:"amountAuthorized"`

--- a/psp/capture.go
+++ b/psp/capture.go
@@ -9,6 +9,7 @@ type CaptureRequest struct {
 }
 
 type CaptureResponse struct {
+	BaseResponse
 	TransactionResponse
 	Capture   CaptureAuthResponse
 	Authorize AuthorizeResponse

--- a/psp/captureauth.go
+++ b/psp/captureauth.go
@@ -17,6 +17,7 @@ type CaptureAuthRequest struct {
 }
 
 type CaptureAuthResponse struct {
+	BaseResponse
 	TransactionResponse
 	AmountCaptured Amount `json:"amountCaptured"`
 }

--- a/psp/fraud.go
+++ b/psp/fraud.go
@@ -17,6 +17,7 @@ type FraudScanRequest struct {
 }
 
 type FraudScanResponse struct {
+	BaseResponse
 	TransactionResponse
 	FraudScore      float32
 	RiskLevel       RiskLevel

--- a/psp/refund.go
+++ b/psp/refund.go
@@ -16,6 +16,7 @@ type RefundRequest struct {
 }
 
 type RefundResponse struct {
+	BaseResponse
 	TransactionResponse
 	AmountRefunded Amount `json:"amount"`
 }

--- a/psp/types.go
+++ b/psp/types.go
@@ -1,6 +1,7 @@
 package psp
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/chargehive/sdk-go-core/payment"
@@ -290,6 +291,51 @@ type BaseTransactionRequest struct {
 	BillPayer                Person                  `json:"billPayer"`
 	Meta                     Meta                    `json:"meta"`
 	CardNetwork              payment.CardNetwork     `json:"cardNetwork"`
+}
+
+type BaseResponse struct {
+	Status *StatusResponse `json:"status"`
+}
+
+func (r *BaseResponse) SetStatus(code int, message string) {
+	r.Status = NewStatus(code, message)
+}
+
+type StatusResponse struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+func NewStatus(code int, message string) *StatusResponse {
+	return &StatusResponse{
+		Message: message,
+		Code:    code,
+	}
+}
+
+func (r *StatusResponse) Error() string {
+	if r == nil {
+		return ""
+	}
+	return fmt.Sprintf("[%d] %s", r.GetCode(), r.GetMessage())
+}
+
+func (r *StatusResponse) IsError() bool {
+	return r.GetCode() >= 300
+}
+
+func (r *StatusResponse) GetMessage() string {
+	if r == nil {
+		return ""
+	}
+	return r.Message
+}
+
+func (r *StatusResponse) GetCode() int {
+	if r == nil {
+		return 200
+	}
+	return r.Code
 }
 
 type SuggestedAction string

--- a/psp/void.go
+++ b/psp/void.go
@@ -15,6 +15,7 @@ type VoidRequest struct {
 }
 
 type VoidResponse struct {
+	BaseResponse
 	TransactionResponse
 }
 


### PR DESCRIPTION
This allows us to return 200 from psp-proxy, but indicate that the transaction failed.

Currently we use the http status as the error code, which isn't accurate since the request succeeded.