### PR TITLE
Refactor CaptureResponse in capture.go for cleaner representation

### DIFF
--- a/psp/authorize.go
+++ b/psp/authorize.go
@@ -21,6 +21,12 @@ type AuthorizeResponse struct {
 	ECI              string         `json:"eci"`
 }
 
+func NewAuthorizeResponse(amountAuthorized Amount) AuthorizeResponse {
+	return AuthorizeResponse{
+		AmountAuthorized: amountAuthorized,
+	}
+}
+
 func (r *AuthorizeRequest) GetPath(credentialID string) string {
 	return "/v1/" + credentialID + "/payment/authorize"
 }

--- a/psp/authorize.go
+++ b/psp/authorize.go
@@ -21,9 +21,9 @@ type AuthorizeResponse struct {
 	ECI              string         `json:"eci"`
 }
 
-func NewAuthorizeResponse(amountAuthorized Amount) AuthorizeResponse {
+func NewAuthorizeResponse(currency string) AuthorizeResponse {
 	return AuthorizeResponse{
-		AmountAuthorized: amountAuthorized,
+		AmountAuthorized: NewAmount(0, currency),
 	}
 }
 

--- a/psp/authorize_test.go
+++ b/psp/authorize_test.go
@@ -45,7 +45,7 @@ func (h testAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	resp := AuthorizeResponse{AmountAuthorized: req.Amount}
+	resp := NewAuthorizeResponse(req.Amount)
 	j, err := json.Marshal(resp)
 	if err != nil {
 		log.Fatal(err)

--- a/psp/authorize_test.go
+++ b/psp/authorize_test.go
@@ -45,7 +45,8 @@ func (h testAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	resp := NewAuthorizeResponse(req.Amount)
+	resp := NewAuthorizeResponse(req.Amount.Currency)
+	resp.AmountAuthorized = req.Amount
 	j, err := json.Marshal(resp)
 	if err != nil {
 		log.Fatal(err)

--- a/psp/capture.go
+++ b/psp/capture.go
@@ -20,7 +20,7 @@ type CaptureResponse struct {
 	Authorize            AuthorizeResponse
 	AuthorizeTransaction *TransactionResponse `json:"authorizeTransaction,omitempty"`
 	ThreeDSResult        *ThreeDSResult       `json:"3dsResult"`
-	AmountAuthorized     Amount               `json:"amountAuthorized"`
+	AmountAuthorized     *Amount              `json:"amountAuthorized"`
 	AuthCode             string               `json:"authCode"`
 	CVVResponse          string               `json:"cvvResponse"`
 	AVS                  string               `json:"avs"`
@@ -36,6 +36,29 @@ func (r *CaptureRequest) Do(conn Connection) (resp CaptureResponse, err error) {
 	if err == nil {
 		err = json.Unmarshal(body, &resp)
 		resp.RequestID = headers.Get(RequestHeaderRequestID)
+
+		if resp.AuthorizeTransaction == nil && resp.Authorize.TransactionResponse.TransactionID != "" {
+			resp.AuthorizeTransaction = &resp.Authorize.TransactionResponse
+		}
+		if resp.ThreeDSResult == nil && resp.Authorize.ThreeDSResult != nil {
+			resp.ThreeDSResult = resp.Authorize.ThreeDSResult
+		}
+		if resp.AmountAuthorized == nil && resp.Authorize.AmountAuthorized.Units != 0 {
+			resp.AmountAuthorized = &resp.Authorize.AmountAuthorized
+		}
+		if resp.AuthCode == "" && resp.Authorize.AuthCode != "" {
+			resp.AuthCode = resp.Authorize.AuthCode
+		}
+		if resp.CVVResponse == "" && resp.Authorize.CVVResponse != "" {
+			resp.CVVResponse = resp.Authorize.CVVResponse
+		}
+		if resp.AVS == "" && resp.Authorize.AVS != "" {
+			resp.AVS = resp.Authorize.AVS
+		}
+		if resp.ECI == "" && resp.Authorize.ECI != "" {
+			resp.ECI = resp.Authorize.ECI
+		}
+
 	}
 
 	return

--- a/psp/capture.go
+++ b/psp/capture.go
@@ -27,6 +27,13 @@ type CaptureResponse struct {
 	ECI                  string               `json:"eci"`
 }
 
+func NewCaptureResponse(amountCaptured Amount) CaptureResponse {
+	return CaptureResponse{
+		Capture:        CaptureAuthResponse{AmountCaptured: amountCaptured},
+		AmountCaptured: amountCaptured,
+	}
+}
+
 func (r *CaptureRequest) GetPath(credentialID string) string {
 	return "/v1/" + credentialID + "/payment/capture"
 }

--- a/psp/capture.go
+++ b/psp/capture.go
@@ -11,8 +11,20 @@ type CaptureRequest struct {
 type CaptureResponse struct {
 	BaseResponse
 	TransactionResponse
-	Capture   CaptureAuthResponse
-	Authorize AuthorizeResponse
+
+	// Deprecated: AmountCaptured is now inline
+	Capture        CaptureAuthResponse
+	AmountCaptured Amount `json:"amountCaptured"`
+
+	// Deprecated: Authorize fields are now inline
+	Authorize            AuthorizeResponse
+	AuthorizeTransaction *TransactionResponse `json:"authorizeTransaction,omitempty"`
+	ThreeDSResult        *ThreeDSResult       `json:"3dsResult"`
+	AmountAuthorized     Amount               `json:"amountAuthorized"`
+	AuthCode             string               `json:"authCode"`
+	CVVResponse          string               `json:"cvvResponse"`
+	AVS                  string               `json:"avs"`
+	ECI                  string               `json:"eci"`
 }
 
 func (r *CaptureRequest) GetPath(credentialID string) string {

--- a/psp/capture.go
+++ b/psp/capture.go
@@ -27,10 +27,9 @@ type CaptureResponse struct {
 	ECI                  string               `json:"eci"`
 }
 
-func NewCaptureResponse(amountCaptured Amount) CaptureResponse {
+func NewCaptureResponse(currency string) CaptureResponse {
 	return CaptureResponse{
-		Capture:        CaptureAuthResponse{AmountCaptured: amountCaptured},
-		AmountCaptured: amountCaptured,
+		Capture: CaptureAuthResponse{AmountCaptured: NewAmount(0, currency)},
 	}
 }
 
@@ -43,6 +42,10 @@ func (r *CaptureRequest) Do(conn Connection) (resp CaptureResponse, err error) {
 	if err == nil {
 		err = json.Unmarshal(body, &resp)
 		resp.RequestID = headers.Get(RequestHeaderRequestID)
+
+		if resp.Capture.AmountCaptured.Units != 0 {
+			resp.AmountCaptured = resp.Capture.AmountCaptured
+		}
 
 		if resp.AuthorizeTransaction == nil && resp.Authorize.TransactionResponse.TransactionID != "" {
 			resp.AuthorizeTransaction = &resp.Authorize.TransactionResponse

--- a/psp/capture_test.go
+++ b/psp/capture_test.go
@@ -26,6 +26,14 @@ func TestCapture(t *testing.T) {
 	if resp.Capture.AmountCaptured != req.Amount {
 		t.Error("capture amount doesn't match")
 	}
+
+	if resp.AmountAuthorized != req.Amount {
+		t.Error("authorize amount doesn't match")
+	}
+
+	if resp.AmountCaptured != req.Amount {
+		t.Error("capture amount doesn't match")
+	}
 }
 
 type testCaptureHandler struct {
@@ -50,8 +58,10 @@ func (h testCaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := CaptureResponse{
-		Authorize: AuthorizeResponse{AmountAuthorized: req.Amount},
-		Capture:   CaptureAuthResponse{AmountCaptured: req.Amount},
+		Authorize:        AuthorizeResponse{AmountAuthorized: req.Amount},
+		AmountAuthorized: req.Amount,
+		Capture:          CaptureAuthResponse{AmountCaptured: req.Amount},
+		AmountCaptured:   req.Amount,
 	}
 	j, _ := json.Marshal(resp)
 	_, _ = w.Write(j)

--- a/psp/capture_test.go
+++ b/psp/capture_test.go
@@ -57,12 +57,9 @@ func (h testCaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	resp := CaptureResponse{
-		Authorize:        AuthorizeResponse{AmountAuthorized: req.Amount},
-		AmountAuthorized: &req.Amount,
-		Capture:          CaptureAuthResponse{AmountCaptured: req.Amount},
-		AmountCaptured:   req.Amount,
-	}
+	resp := NewCaptureResponse(req.Amount)
+	resp.Authorize = AuthorizeResponse{AmountAuthorized: req.Amount}
+
 	j, _ := json.Marshal(resp)
 	_, _ = w.Write(j)
 }

--- a/psp/capture_test.go
+++ b/psp/capture_test.go
@@ -27,7 +27,7 @@ func TestCapture(t *testing.T) {
 		t.Error("capture amount doesn't match")
 	}
 
-	if resp.AmountAuthorized != req.Amount {
+	if resp.AmountAuthorized == nil || (resp.AmountAuthorized.Units != req.Amount.Units && resp.AmountAuthorized.Currency != req.Amount.Currency) {
 		t.Error("authorize amount doesn't match")
 	}
 
@@ -59,7 +59,7 @@ func (h testCaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resp := CaptureResponse{
 		Authorize:        AuthorizeResponse{AmountAuthorized: req.Amount},
-		AmountAuthorized: req.Amount,
+		AmountAuthorized: &req.Amount,
 		Capture:          CaptureAuthResponse{AmountCaptured: req.Amount},
 		AmountCaptured:   req.Amount,
 	}

--- a/psp/capture_test.go
+++ b/psp/capture_test.go
@@ -57,7 +57,8 @@ func (h testCaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	resp := NewCaptureResponse(req.Amount)
+	resp := NewCaptureResponse(req.Amount.Currency)
+	resp.Capture.AmountCaptured = req.Amount
 	resp.Authorize = AuthorizeResponse{AmountAuthorized: req.Amount}
 
 	j, _ := json.Marshal(resp)

--- a/psp/captureauth.go
+++ b/psp/captureauth.go
@@ -22,6 +22,12 @@ type CaptureAuthResponse struct {
 	AmountCaptured Amount `json:"amountCaptured"`
 }
 
+func NewCaptureAuthResponse(amountCaptured Amount) CaptureAuthResponse {
+	return CaptureAuthResponse{
+		AmountCaptured: amountCaptured,
+	}
+}
+
 func (r *CaptureAuthRequest) GetPath(credentialID string) string {
 	return "/v1/" + credentialID + "/payment/capture-auth"
 }

--- a/psp/captureauth.go
+++ b/psp/captureauth.go
@@ -22,9 +22,9 @@ type CaptureAuthResponse struct {
 	AmountCaptured Amount `json:"amountCaptured"`
 }
 
-func NewCaptureAuthResponse(amountCaptured Amount) CaptureAuthResponse {
+func NewCaptureAuthResponse(currency string) CaptureAuthResponse {
 	return CaptureAuthResponse{
-		AmountCaptured: amountCaptured,
+		AmountCaptured: NewAmount(0, currency),
 	}
 }
 

--- a/psp/captureauth_test.go
+++ b/psp/captureauth_test.go
@@ -49,7 +49,8 @@ func (h testCaptureAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		log.Fatal(err)
 	}
 
-	resp := NewCaptureAuthResponse(req.Amount)
+	resp := NewCaptureAuthResponse(req.Amount.Currency)
+	resp.AmountCaptured = req.Amount
 	resp.GatewayTransactionID = req.AuthorizeID + ":captured"
 	j, _ := json.Marshal(resp)
 	_, _ = w.Write(j)

--- a/psp/captureauth_test.go
+++ b/psp/captureauth_test.go
@@ -49,7 +49,7 @@ func (h testCaptureAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		log.Fatal(err)
 	}
 
-	resp := CaptureAuthResponse{AmountCaptured: req.Amount}
+	resp := NewCaptureAuthResponse(req.Amount)
 	resp.GatewayTransactionID = req.AuthorizeID + ":captured"
 	j, _ := json.Marshal(resp)
 	_, _ = w.Write(j)

--- a/psp/refund.go
+++ b/psp/refund.go
@@ -21,9 +21,9 @@ type RefundResponse struct {
 	AmountRefunded Amount `json:"amount"`
 }
 
-func NewRefundResponse(amountRefunded Amount) RefundResponse {
+func NewRefundResponse(currency string) RefundResponse {
 	return RefundResponse{
-		AmountRefunded: amountRefunded,
+		AmountRefunded: NewAmount(0, currency),
 	}
 }
 

--- a/psp/refund.go
+++ b/psp/refund.go
@@ -21,6 +21,12 @@ type RefundResponse struct {
 	AmountRefunded Amount `json:"amount"`
 }
 
+func NewRefundResponse(amountRefunded Amount) RefundResponse {
+	return RefundResponse{
+		AmountRefunded: amountRefunded,
+	}
+}
+
 func (r *RefundRequest) GetPath(credentialID string) string {
 	return "/v1/" + credentialID + "/payment/refund"
 }

--- a/psp/refund_test.go
+++ b/psp/refund_test.go
@@ -49,7 +49,8 @@ func (h testRefundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	resp := NewRefundResponse(req.Amount)
+	resp := NewRefundResponse(req.Amount.Currency)
+	resp.AmountRefunded = req.Amount
 	resp.GatewayTransactionID = req.AuthorizeID + ":refunded"
 	j, _ := json.Marshal(resp)
 	_, _ = w.Write(j)

--- a/psp/refund_test.go
+++ b/psp/refund_test.go
@@ -1,0 +1,56 @@
+package psp
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"testing"
+)
+
+func TestRefund(t *testing.T) {
+	h := testRefundHandler{c: testHandlerCredentials{"abc", "123"}}
+
+	con := NewTestConnection(h)
+	req := RefundRequest{AuthorizeID: "abc123", Amount: NewAmount(123, "USD")}
+	resp, err := req.Do(con)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.AmountRefunded != req.Amount {
+		t.Error("amount doesn't match")
+	}
+
+	if resp.GatewayTransactionID != req.AuthorizeID+":refunded" {
+		t.Error("unexpected gateway transaction id")
+	}
+}
+
+type testRefundHandler struct {
+	testHandler
+	c testHandlerCredentials
+}
+
+func (h testRefundHandler) GetHandlerCredentials() testHandlerCredentials {
+	return h.c
+}
+
+func (h testRefundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	req := RefundRequest{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp := NewRefundResponse(req.Amount)
+	resp.GatewayTransactionID = req.AuthorizeID + ":refunded"
+	j, _ := json.Marshal(resp)
+	_, _ = w.Write(j)
+}

--- a/psp/void.go
+++ b/psp/void.go
@@ -19,6 +19,10 @@ type VoidResponse struct {
 	TransactionResponse
 }
 
+func NewVoidResponse() VoidResponse {
+	return VoidResponse{}
+}
+
 func (r *VoidRequest) GetPath(credentialID string) string {
 	return "/v1/" + credentialID + "/payment/void"
 }

--- a/psp/void_test.go
+++ b/psp/void_test.go
@@ -1,0 +1,52 @@
+package psp
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"testing"
+)
+
+func TestVoid(t *testing.T) {
+	h := testVoidHandler{c: testHandlerCredentials{"abc", "123"}}
+
+	con := NewTestConnection(h)
+	req := VoidRequest{AuthorizeID: "abc123", Amount: NewAmount(123, "USD")}
+	resp, err := req.Do(con)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.GatewayTransactionID != req.AuthorizeID+":voided" {
+		t.Error("unexpected gateway transaction id")
+	}
+}
+
+type testVoidHandler struct {
+	testHandler
+	c testHandlerCredentials
+}
+
+func (h testVoidHandler) GetHandlerCredentials() testHandlerCredentials {
+	return h.c
+}
+
+func (h testVoidHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	req := VoidRequest{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp := NewVoidResponse()
+	resp.GatewayTransactionID = req.AuthorizeID + ":voided"
+	j, _ := json.Marshal(resp)
+	_, _ = w.Write(j)
+}


### PR DESCRIPTION
Refactored capture.go by making changes to the 'CaptureResponse' struct to better present the authorization and capture amounts as inline fields, instead of being nested in other structs. Additionally, deprecated fields have been marked accordingly. This change simplifies the creation and reading of CaptureResponse instances, leading to cleaner and more readable code.